### PR TITLE
Fix teleport detection after random tab flip

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -287,8 +287,11 @@ def spam_session():
     burst=gaussian_between(SPAM_MIN,SPAM_MAX)
     rest =gaussian_between(REST_MIN,REST_MAX)
 
-    if not safe_locate(MAGIC_OPEN_IMAGE, confidence=OPEN_CONFIDENCE, grayscale=True):
-        click_magic_tab()
+    # Always click the Magic tab before attempting to locate the teleport.
+    # Sometimes random tab flips leave another tab active which prevents the
+    # teleport icon from being found. Clicking the Magic tab each session is
+    # cheap and ensures the spellbook is visible.
+    click_magic_tab()
 
     loc=safe_locate(TELEPORT_IMAGE, confidence=CONFIDENCE, grayscale=True)
     if not loc:


### PR DESCRIPTION
## Summary
- always click the Magic tab before each spam session

This prevents the bot from failing to locate the teleport spell if a different tab was active.

## Testing
- `python -m py_compile src/EssayReview.pyw src/DraftTracker.py`

------
https://chatgpt.com/codex/tasks/task_e_685fcc6f3648832fa7fbbccf6dc577f1