### PR TITLE
Fix teleport search when rune missing

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -324,7 +324,13 @@ def spam_session():
 
     loc=safe_locate(TELEPORT_IMAGE, confidence=CONFIDENCE, grayscale=True)
     if not loc:
-        log("Teleport rune not found; skipping burst."); return
+        log("Teleport rune not found; clicking Magic tab...")
+        if not click_magic_tab():
+            log("Teleport rune not found and could not open Magic tab; skipping burst.")
+            return
+        loc=safe_locate(TELEPORT_IMAGE, confidence=CONFIDENCE, grayscale=True)
+        if not loc:
+            log("Teleport rune still not found; skipping burst."); return
     x,y = pag.center(loc)
     log(f"Click burst {burst:.1f}s at {(x,y)}")
     end=time.time()+burst


### PR DESCRIPTION
## Summary
- try clicking Magic tab again if the teleport rune isn't found

## Testing
- `python -m py_compile src/EssayReview.pyw src/DraftTracker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd14eb444832fab97778ed9a0b8ac