### PR TITLE
Implement F7 fallback for teleport search

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ rename it to `EssayReview.py` and launch it the same way.
 
 A prompt asks which teleport to spam-click. After selecting a teleport, the bot begins clicking. The overlay window appears near the RuneLite window and can be dragged or resized; geometry is saved in `overlay_pos.json`.
 
-Press **F1** at any time to pause or resume automation. Press **F2** to show or hide the console window. Press **F3** to stop the bot completely.
+Press **F1** at any time to pause or resume automation. Press **F2** to show or hide the console window. Press **F3** to stop the bot completely. If the teleport tab still cannot be found after the bot attempts to open it, it will press **F7** automatically as a fallback.
 

--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -328,9 +328,15 @@ def spam_session():
         if not click_magic_tab():
             log("Teleport rune not found and could not open Magic tab; skipping burst.")
             return
-        loc=safe_locate(TELEPORT_IMAGE, confidence=CONFIDENCE, grayscale=True)
+        loc = safe_locate(TELEPORT_IMAGE, confidence=CONFIDENCE, grayscale=True)
         if not loc:
-            log("Teleport rune still not found; skipping burst."); return
+            log("Teleport rune still not found; pressing F7...")
+            pag.press('f7')
+            time.sleep(0.5)
+            loc = safe_locate(TELEPORT_IMAGE, confidence=CONFIDENCE, grayscale=True)
+            if not loc:
+                log("Teleport rune still not found; skipping burst.")
+                return
     x,y = pag.center(loc)
     log(f"Click burst {burst:.1f}s at {(x,y)}")
     end=time.time()+burst


### PR DESCRIPTION
## Summary
- retry teleport lookup by pressing F7 when the rune cannot be found
- document the new F7 behaviour in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fd28aad88832facb006e6ee767217