### PR TITLE
Change fallback teleport key to F6

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ rename it to `EssayReview.py` and launch it the same way.
 
 A prompt asks which teleport to spam-click. After selecting a teleport, the bot begins clicking. The overlay window appears near the RuneLite window and can be dragged or resized; geometry is saved in `overlay_pos.json`.
 
-Press **F1** at any time to pause or resume automation. Press **F2** to show or hide the console window. Press **F3** to stop the bot completely. If the teleport tab still cannot be found after the bot attempts to open it, it will press **F7** automatically as a fallback.
+Press **F1** at any time to pause or resume automation. Press **F2** to show or hide the console window. Press **F3** to stop the bot completely. If the teleport tab still cannot be found after the bot attempts to open it, it will press **F6** automatically as a fallback.
 

--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -330,8 +330,8 @@ def spam_session():
             return
         loc = safe_locate(TELEPORT_IMAGE, confidence=CONFIDENCE, grayscale=True)
         if not loc:
-            log("Teleport rune still not found; pressing F7...")
-            pag.press('f7')
+            log("Teleport rune still not found; pressing F6...")
+            pag.press('f6')
             time.sleep(0.5)
             loc = safe_locate(TELEPORT_IMAGE, confidence=CONFIDENCE, grayscale=True)
             if not loc:


### PR DESCRIPTION
## Summary
- update README instructions for Magic tab
- change fallback key from F7 to F6 in script

## Testing
- `python -m py_compile src/EssayReview.pyw`

------
https://chatgpt.com/codex/tasks/task_e_685fd3c8dff8832faafb0613bcf75b03