### PR TITLE
Remove console printing

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -55,7 +55,6 @@ def toggle_console():
 
 def log(msg: str):
     stamp = datetime.now().strftime("%H:%M:%S")
-    print(stamp, msg, flush=True)
     overlay.update_log(f"{stamp} {msg}")
 
 # ───────────────────── PyAutoGUI tweaks ────────────────────────────


### PR DESCRIPTION
## Summary
- remove stdout printing from `log`

## Testing
- `python -m py_compile src/*.pyw src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685fdcadc3e4832facad5c033d808788