### PR TITLE
Add env toggle to disable overlay HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project contains **EssayReview.pyw**, a teleport spam bot for Old School Ru
 
 - Supports Varrock, Falador and Camelot teleports (prompted at start).
 - Overlay HUD showing recent log lines and a magic cape image.
+  Set `OSRS_NO_OVERLAY=1` to run without it.
 - Anti-ban behaviour with varying click timings and occasional idle actions.
 - Hotkeys: **1** to pause/resume, **2** to toggle the console, **3** to quit.
 
@@ -40,7 +41,7 @@ opens on Windows. If you prefer to see the console output you can
 rename it to `EssayReview.py` and launch it the same way.
 
 
-A prompt asks which teleport to spam-click. After selecting a teleport, the bot begins clicking. The overlay window appears near the RuneLite window and can be dragged or resized; geometry is saved in `overlay_pos.json`.
+A prompt asks which teleport to spam-click. After selecting a teleport, the bot begins clicking. The overlay window appears near the RuneLite window and can be dragged or resized; geometry is saved in `overlay_pos.json`. Set `OSRS_NO_OVERLAY=1` before launching if you do not want the HUD.
 
 Press **1** at any time to pause or resume automation. Press **2** to show or hide the console window. Press **3** to stop the bot completely. If the teleport tab still cannot be found after the bot attempts to open it, it will press **F6** automatically as a fallback.
 

--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -18,11 +18,13 @@ from .DraftTracker import DraftTracker
 import pygetwindow as gw
 
 # ───────────────────────── Overlay logger ──────────────────────────
-overlay = DraftTracker()
-try:
-    overlay.set_cape_scale(3.0)         # enlarge cape ×2
-except AttributeError:
-    pass
+OVERLAY_DISABLED = os.getenv("OSRS_NO_OVERLAY")
+overlay = None if OVERLAY_DISABLED else DraftTracker()
+if overlay:
+    try:
+        overlay.set_cape_scale(3.0)         # enlarge cape ×2
+    except AttributeError:
+        pass
 
 
 # ─────────────────── Console visibility helpers ───────────────────
@@ -56,7 +58,8 @@ def toggle_console():
 def log(msg: str):
     stamp = datetime.now().strftime("%H:%M:%S")
     print(stamp, msg, flush=True)
-    overlay.update_log(f"{stamp} {msg}")
+    if overlay:
+        overlay.update_log(f"{stamp} {msg}")
 
 # ───────────────────── PyAutoGUI tweaks ────────────────────────────
 pag.FAILSAFE = False


### PR DESCRIPTION
## Summary
- allow disabling the overlay HUD via `OSRS_NO_OVERLAY` environment variable
- document the environment variable in README

## Testing
- `python -m py_compile src/EssayReview.pyw src/DraftTracker.py`
- `pip install -r requirements.txt` *(fails: no pywin32)*

------
https://chatgpt.com/codex/tasks/task_e_685fdd4bb6f8832fae0a91a3e5562488