### PR TITLE
Lower Magic tab detection confidence

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -132,7 +132,8 @@ TAB_IMAGES = [   # side-panel sprites for random flips
 CONFIDENCE = 0.90
 STATS_CONFIDENCE = 0.80
 OPEN_CONFIDENCE = 0.85
-MAGIC_TAB_CONFIDENCE = 0.88
+# Lowered threshold for locating MagicTab.png
+MAGIC_TAB_CONFIDENCE = 0.80
 
 # ───────────────── Behaviour constants ────────────────────────────
 SPAM_MIN, SPAM_MAX = 1, 70


### PR DESCRIPTION
## Summary
- reduce Magic tab image confidence threshold so it matches more easily

## Testing
- `python3 -m py_compile src/EssayReview.pyw`


------
https://chatgpt.com/codex/tasks/task_e_6860939cb48c832f903ffcf4813a8fb5