### PR TITLE
Improve stopping behavior

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -297,9 +297,13 @@ def bezier_move(tx, ty):
                    b=random.uniform(.04, .07))
     # Add built-in random variation and slower baseline
     T *= random.uniform(1.6, 2.4)
+    fx, fy = path[-1]
     for (sx, sy), (px, py) in zip(path[:-1], path[1:]):
         seg = math.hypot(px - sx, py - sy)
-        seg_T = seg / total * T * random.uniform(0.8, 1.2)
+        remaining = math.hypot(fx - px, fy - py)
+        vel_factor = clamp(remaining / total, 0.25, 1.0)
+        seg_T = seg / total * T / vel_factor
+        seg_T *= random.uniform(0.8, 1.2)
         pag.moveTo(px, py, duration=clamp(seg_T, .01, .90),
                    tween=random.choice(TWEEN_FUNCS))
 


### PR DESCRIPTION
## Summary
- slow down at end of bezier_move paths

## Testing
- `python -m py_compile src/EssayReview.pyw`
- `python -m py_compile src/*.py src/*.pyw`


------
https://chatgpt.com/codex/tasks/task_e_6860be1c7b94832fa245e74c91c19139