### PR TITLE
Enable console logging

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -82,6 +82,7 @@ def toggle_console():
 def log(msg: str):
     stamp = datetime.now().strftime("%H:%M:%S")
     overlay.update_log(f"{stamp} {msg}")
+    print(f"{stamp} {msg}", flush=True)
 
 
 # ───────────────────── PyAutoGUI tweaks ────────────────────────────


### PR DESCRIPTION
## Summary
- show log messages in the console again

## Testing
- `python -m py_compile src/EssayReview.pyw src/DraftTracker.py`


------
https://chatgpt.com/codex/tasks/task_e_6860ca06eb54832fad89700a47c5caf8