### PR TITLE
Fix locate error

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -122,8 +122,8 @@ def safe_locate(img, **kw):
         else:
             debug(f"Image {os.path.basename(img)} not found")
         return loc
-    except ImageNotFoundException:
-        debug(f"Image {os.path.basename(img)} not found (exception)")
+    except (ImageNotFoundException, ValueError) as e:
+        debug(f"Locate failed for {os.path.basename(img)}: {e}")
         return None
 
 
@@ -648,7 +648,7 @@ def spam_session():
                 TELEPORT_IMAGE,
                 confidence=CONFIDENCE,
                 grayscale=True,
-                region=(x - 5, y - 5, 10, 10),
+                region=(x - 20, y - 20, 40, 40),
             )
             if chk:
                 debug("click retry")

--- a/tests/test_safe_locate.py
+++ b/tests/test_safe_locate.py
@@ -1,0 +1,71 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import sys
+import os
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Dummy pyautogui that raises ValueError on locateOnScreen
+class DummyPag:
+    def __init__(self):
+        self.FAILSAFE = False
+        self.PAUSE = 0
+        self.ImageNotFoundException = Exception
+        self._pos = [0, 0]
+        self.easeInQuad = self.easeOutQuad = self.easeInOutQuad = (
+            self.easeInCubic
+        ) = self.easeOutCubic = self.easeInOutCubic = lambda x: x
+
+    def locateOnScreen(self, *a, **k):
+        raise ValueError('needle dimension(s) exceed the haystack image or region dimensions')
+
+    def confirm(self, *a, **k):
+        return 'Varrock'
+
+    # stubs required for module import
+    def moveTo(self, *a, **k):
+        pass
+    def moveRel(self, *a, **k):
+        pass
+    def position(self):
+        return tuple(self._pos)
+    def click(self, *a, **k):
+        pass
+    def size(self):
+        return (800, 600)
+    def press(self, *a, **k):
+        pass
+    def scroll(self, *a, **k):
+        pass
+
+pag = DummyPag()
+sys.modules['pyautogui'] = pag
+sys.modules['pygetwindow'] = SimpleNamespace()
+sys.modules.setdefault('win32gui', SimpleNamespace())
+sys.modules.setdefault('win32con', SimpleNamespace())
+
+class DummyOverlay:
+    def update_log(self, msg):
+        pass
+    def set_cape_scale(self, factor):
+        pass
+
+import types
+DraftTracker = types.ModuleType('src.DraftTracker')
+DraftTracker.DraftTracker = DummyOverlay
+sys.modules['src.DraftTracker'] = DraftTracker
+
+file_path = os.path.join(os.path.dirname(__file__), '..', 'src', 'EssayReview.pyw')
+loader = importlib.machinery.SourceFileLoader('src.EssayReview', file_path)
+spec = importlib.util.spec_from_loader('src.EssayReview', loader)
+ER = importlib.util.module_from_spec(spec)
+loader.exec_module(ER)
+
+class SafeLocateTest(unittest.TestCase):
+    def test_safe_locate_handles_value_error(self):
+        self.assertIsNone(ER.safe_locate('dummy.png'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle ValueError from locateOnScreen and log the failure
- expand the click verification region so the image fits
- add a unit test ensuring safe_locate catches the error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860e907d358832f883c68910524c13f