### PR TITLE
Add configuration window

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ rename it to `EssayReview.py` and launch it the same way. Logs now always
 print to the terminal so you can monitor activity and debug issues.
 
 
-A prompt asks which teleport to spam-click. After selecting a teleport, the bot begins clicking. The overlay window appears near the RuneLite window and can be dragged or resized; geometry is saved in `overlay_pos.json`.
+A configuration window first lets you choose the teleport and toggle options like the overlay, mouse overshoot and velocity limit. After clicking **Start** the bot begins spamming the chosen teleport. When enabled, the overlay window appears near the RuneLite window and can be dragged or resized; its geometry is saved in `overlay_pos.json`.
 
 Press **1** at any time to pause or resume automation. Press **2** to show or hide the console window. Press **3** to stop the bot completely. If the teleport tab still cannot be found after the bot attempts to open it, it will press **F6** automatically as a fallback.
 


### PR DESCRIPTION
## Summary
- add GUI config prompt for teleport selection and toggling features
- initialize overlay after reading config
- document the new configuration step in README

## Testing
- `pip install pyautogui pygetwindow Pillow keyboard`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860eba780bc832f9034700a917cc4ed