### PR TITLE
Update display gating logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,7 @@ print to the terminal so you can monitor activity and debug issues.
 
 A configuration window first lets you choose the teleport and toggle options like the overlay, mouse overshoot and velocity limit. After clicking **Start** the bot begins spamming the chosen teleport. When enabled, the overlay window appears near the RuneLite window and can be dragged or resized; its geometry is saved in `overlay_pos.json`.
 
+On non-Windows systems the window is only shown when the `DISPLAY` environment variable is set. It is also skipped automatically during test runs.
+
 Press **1** at any time to pause or resume automation. Press **2** to show or hide the console window. Press **3** to stop the bot completely. If the teleport tab still cannot be found after the bot attempts to open it, it will press **F6** automatically as a fallback.
 

--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -91,7 +91,9 @@ def log(msg: str):
 
 def config_prompt():
     """Interactive window for teleport and feature settings."""
-    if "PYTEST_CURRENT_TEST" in os.environ or not os.environ.get("DISPLAY"):
+    if "PYTEST_CURRENT_TEST" in os.environ or (
+        os.name != "nt" and not os.environ.get("DISPLAY")
+    ):
         # during automated tests or headless environments use defaults
         global choice
         choice = list(OPTIONS.keys())[0]


### PR DESCRIPTION
## Summary
- skip config window if DISPLAY is missing on non-Windows systems
- mention DISPLAY behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ef79e270832f91e89c0024508b74