### PR TITLE
Add option to disable AFK events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project contains **EssayReview.pyw**, a teleport spam bot for Old School Ru
 - Randomised cursor speed for more human-like movement.
 - Optional "robust click" mode that holds the mouse
   button down briefly so clicks aren't missed on some setups.
+- Option to disable all AFK events in the configuration window.
 - Hotkeys: **1** to pause/resume, **2** to toggle the console, **3** to quit.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- add `ENABLE_AFK` option and expose it in the configuration window
- skip AFK routines when disabled
- handle missing `keyboard` module for tests
- document the new option in the README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860f90c6e68832f81a825653b9ec51c