### PR TITLE
Add toggle to disable rest between bursts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project contains **EssayReview.pyw**, a teleport spam bot for Old School Ru
   button down briefly so clicks aren't missed on some setups.
 - Option to disable all AFK events in the configuration window.
 - New toggles let you disable stats hovering, Edge/YouTube AFK tasks
-  and random tab flips if desired.
+  random tab flips and the short rest between bursts if desired.
 - Simple login helper that clicks the RuneScape launcher buttons.
 - Hotkeys: **1** to pause/resume, **2** to toggle the console, **3** to quit.
 
@@ -48,7 +48,7 @@ rename it to `EssayReview.py` and launch it the same way. Logs now always
 print to the terminal so you can monitor activity and debug issues.
 
 
-A configuration window first lets you choose the teleport and toggle options like the overlay, mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks and tab flipping. After clicking **Start** the bot begins spamming the chosen teleport. When enabled, the overlay window appears near the RuneLite window and can be dragged or resized; its geometry is saved in `overlay_pos.json`.
+ A configuration window first lets you choose the teleport and toggle options like the overlay, mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks, tab flipping and the short rest after each burst. After clicking **Start** the bot begins spamming the chosen teleport. When enabled, the overlay window appears near the RuneLite window and can be dragged or resized; its geometry is saved in `overlay_pos.json`.
 
 On non-Windows systems the window is only shown when the `DISPLAY` environment variable is set. It is also skipped automatically during test runs.
 

--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -79,6 +79,10 @@ ENABLE_BROWSER_AFK = True
 # If enabled the bot flips through random side tabs while idling.
 ENABLE_TAB_FLIP = True
 
+# Disable the brief rest between click bursts. When off the bot immediately
+# starts the next burst without pausing.
+ENABLE_REST = True
+
 
 
 class _DummyOverlay:
@@ -190,6 +194,7 @@ def config_prompt():
     stats_var = tk.BooleanVar(value=ENABLE_STATS_HOVER)
     browser_var = tk.BooleanVar(value=ENABLE_BROWSER_AFK)
     tabflip_var = tk.BooleanVar(value=ENABLE_TAB_FLIP)
+    rest_var = tk.BooleanVar(value=ENABLE_REST)
 
     tk.Label(root, text="Options:", bg=bg, fg=fg).pack(anchor="w", padx=10, pady=(10, 0))
 
@@ -228,12 +233,14 @@ def config_prompt():
     add_switch("Hover stats during rests", stats_var)
     add_switch("Use Edge/YouTube during AFK", browser_var)
     add_switch("Random tab flips when idle", tabflip_var)
+    add_switch("Rest between bursts", rest_var)
 
     def _start():
         global ENABLE_OVERLAY, ENABLE_OVERSHOOT, ENABLE_JITTER
         global ENABLE_VELOCITY_LIMIT, CHECK_FINAL_POS, LOG_CLICKS, ROBUST_CLICK
         global ENABLE_AFK, ENABLE_ANTIBAN
         global ENABLE_STATS_HOVER, ENABLE_BROWSER_AFK, ENABLE_TAB_FLIP, choice
+        global ENABLE_REST
         ENABLE_OVERLAY = overlay_var.get()
         ENABLE_OVERSHOOT = over_var.get()
         ENABLE_JITTER = jitter_var.get()
@@ -246,6 +253,7 @@ def config_prompt():
         ENABLE_STATS_HOVER = stats_var.get()
         ENABLE_BROWSER_AFK = browser_var.get()
         ENABLE_TAB_FLIP = tabflip_var.get()
+        ENABLE_REST = rest_var.get()
         choice = tele_var.get()
         root.destroy()
 
@@ -882,8 +890,11 @@ def spam_session():
         if feature("idle_wiggle"):
             idle_wiggle()
 
-    log(f"Burst done. Rest {rest:.1f}s...")
-    handle_short_rest(rest)
+    if ENABLE_REST:
+        log(f"Burst done. Rest {rest:.1f}s...")
+        handle_short_rest(rest)
+    else:
+        log("Burst done. Rest skipped.")
 
 
 


### PR DESCRIPTION
## Summary
- introduce `ENABLE_REST` configuration option
- expose rest switch in the configuration dialog
- skip calling `handle_short_rest` when rests are disabled
- document the new toggle in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686119269138832fa612b5251c99b4a1