### PR TITLE
Add teleport confidence setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ rename it to `EssayReview.py` and launch it the same way. Logs now always
 print to the terminal so you can monitor activity and debug issues.
 
 
- A configuration window first lets you choose the teleport and toggle options like the overlay, mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks, tab flipping and the short rest after each burst. After clicking **Start** the bot begins spamming the chosen teleport. When enabled, the overlay window appears near the RuneLite window and can be dragged or resized; its geometry is saved in `overlay_pos.json`.
+ A configuration window first lets you choose the teleport and toggle options like the overlay, mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks, tab flipping and the short rest after each burst. You can also enter the confidence threshold used to locate `Cam.png` (or other teleport icons). After clicking **Start** the bot begins spamming the chosen teleport. When enabled, the overlay window appears near the RuneLite window and can be dragged or resized; its geometry is saved in `overlay_pos.json`.
 
 On non-Windows systems the window is only shown when the `DISPLAY` environment variable is set. It is also skipped automatically during test runs.
 


### PR DESCRIPTION
## Summary
- allow user to specify teleport icon confidence
- pass new TELEPORT_CONFIDENCE constant to image searches
- document the new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611c06f3c4832fafdbbf1ca59a892e