### PR TITLE
Fix stop segment clamping in bezier_move

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -613,6 +613,8 @@ def bezier_move(tx, ty, *, jitter_prob=None, jitter_px=None):
             if v > allowed_v:
                 v = allowed_v
                 seg_T = seg_len / v
+                seg_T = clamp(seg_T, 0.01, 0.90)
+                v = seg_len / seg_T
         last_move_velocities.append(v)
         debug(
             f"seg to {(px, py)} len={seg_len:.1f} T={seg_T:.3f} v={v:.1f}"


### PR DESCRIPTION
## Summary
- clamp deceleration segment length again when limiting end velocity
- recompute segment velocity after clamping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686120d91b6c832fb725a23fe9bf0cd9