### PR TITLE
Lower default teleport confidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ rename it to `EssayReview.py` and launch it the same way. Logs now always
 print to the terminal so you can monitor activity and debug issues.
 
 
- A configuration window first lets you choose the teleport and toggle options like the overlay, mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks, tab flipping and the short rest after each burst. You can also enter the confidence threshold used to locate `Cam.png` (or other teleport icons). After clicking **Start** the bot begins spamming the chosen teleport. When enabled, the overlay window appears near the RuneLite window and can be dragged or resized; its geometry is saved in `overlay_pos.json`.
+ A configuration window first lets you choose the teleport and toggle options like the overlay, mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks, tab flipping and the short rest after each burst. You can also enter the confidence threshold used to locate `Cam.png` (or other teleport icons). The default value is **0.8**. After clicking **Start** the bot begins spamming the chosen teleport. When enabled, the overlay window appears near the RuneLite window and can be dragged or resized; its geometry is saved in `overlay_pos.json`.
 
 On non-Windows systems the window is only shown when the `DISPLAY` environment variable is set. It is also skipped automatically during test runs.
 

--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -98,7 +98,7 @@ class _DummyOverlay:
 overlay: object = _DummyOverlay()
 
 # Default confidence for image recognition
-CONFIDENCE = 0.90
+CONFIDENCE = 0.80
 TELEPORT_CONFIDENCE = CONFIDENCE
 
 


### PR DESCRIPTION
## Summary
- lower default image recognition confidence to 0.8
- document the new default in the README

## Testing
- `python -m pip install -r requirements.txt` *(fails: No matching distribution found for pywin32)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686126570820832fbc24ccf908a150b0