### PR TITLE
Fix packaging of assets for executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Press **1** at any time to pause or resume automation. Press **2** to show or hi
 
 ## Building an executable
 
-Use the `build-exe.bat` script to create an executable version of the bot:
+Use the `build-exe.bat` script to create an executable version of the bot. This
+script now includes the `assets` folder so the bundled executable can locate the
+image files it needs:
 
 ```cmd
 build-exe.bat

--- a/build-exe.bat
+++ b/build-exe.bat
@@ -8,7 +8,8 @@ REM Install PyInstaller if missing
 python -m pip install --upgrade pyinstaller
 
 REM Build the executable
-pyinstaller --onefile --windowed --name EssayReview src\EssayReview.pyw
+pyinstaller --onefile --windowed --name EssayReview \
+    --add-data "assets;assets" src\EssayReview.pyw
 
 echo.
 echo ✅ Build complete. Executable is in the dist folder.


### PR DESCRIPTION
## Summary
- include `assets` folder when building `EssayReview.exe`
- mention asset bundling in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68632dac18d8832f88476e5be5cc6377