### PR TITLE
Fix unhandled asset read errors

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -379,7 +379,7 @@ def safe_locate(img, **kw):
         else:
             debug(f"Image {os.path.basename(img)} not found")
         return loc
-    except (ImageNotFoundException, ValueError) as e:
+    except (ImageNotFoundException, ValueError, OSError) as e:
         debug(f"Locate failed for {os.path.basename(img)}: {e}")
         return None
 


### PR DESCRIPTION
## Summary
- handle `OSError` in `safe_locate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686356b7f02c832fa5615e753d859659