### PR TITLE
Fix PyInstaller asset path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Press **1** at any time to pause or resume automation. Press **2** to show or hi
 
 Use the `build-exe.bat` script to create an executable version of the bot. This
 script now includes the `assets` folder so the bundled executable can locate the
-image files it needs:
+image files it needs. `EssayReview.pyw` checks the `sys._MEIPASS` attribute when
+running from PyInstaller so the assets load correctly:
 
 ```cmd
 build-exe.bat

--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -24,7 +24,7 @@ from datetime import datetime
 
 # absolute paths ------------------------------------------------------------
 PKG_DIR = os.path.dirname(__file__)
-ROOT_DIR = os.path.abspath(os.path.join(PKG_DIR, os.pardir))
+ROOT_DIR = getattr(sys, "_MEIPASS", os.path.abspath(os.path.join(PKG_DIR, os.pardir)))
 ASSETS_DIR = os.path.join(ROOT_DIR, "assets")
 
 # Feature toggles ----------------------------------------------------


### PR DESCRIPTION
## Summary
- load assets from `sys._MEIPASS` when running as an executable
- note the PyInstaller logic in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635d5196f0832f83761cebbd3095c5