### PR TITLE
Add AFK frequency slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project contains **EssayReview.pyw**, a teleport spam bot for Old School Ru
 - New toggles let you disable stats hovering, Edge/YouTube AFK tasks
   random tab flips and the short rest between bursts if desired.
 - Entry to adjust how often short AFK tasks occur during those rests.
+- Slider to control how frequently the bot takes AFK breaks.
 - Simple login helper that clicks the RuneScape launcher buttons.
 - Hotkeys: **1** to pause/resume, **2** to toggle the console, **3** to quit.
 
@@ -48,7 +49,7 @@ rename it to `EssayReview.py` and launch it the same way. Logs now always
 print to the terminal so you can monitor activity and debug issues.
 
 
- A configuration window first lets you choose the teleport and toggle options like mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks, tab flipping and the short rest after each burst. There is also a field to set how often a short AFK task should run. You can also enter the confidence threshold used to locate `Cam.png` (or other teleport icons). The default value is **0.8**. After clicking **Start** the bot begins spamming the chosen teleport.
+ A configuration window first lets you choose the teleport and toggle options like mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks, tab flipping and the short rest after each burst. There is also a field to set how often a short AFK task should run. A slider lets you adjust the overall AFK break frequency. You can also enter the confidence threshold used to locate `Cam.png` (or other teleport icons). The default value is **0.8**. After clicking **Start** the bot begins spamming the chosen teleport.
 
 On non-Windows systems the window is only shown when the `DISPLAY` environment variable is set. It is also skipped automatically during test runs.
 


### PR DESCRIPTION
## Summary
- allow adjusting AFK frequency via configuration window
- compute AFK timings from new slider value
- document new AFK frequency option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68636b5d4ec0832fa1819795faa7b53a