### PR TITLE
Fix config_prompt initialization order

### DIFF
--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -480,18 +480,7 @@ def update_afk_settings() -> None:
 pag.FAILSAFE = False
 pag.PAUSE = 0
 
-# ─────────────────── Teleport selection prompt ─────────────────────
-OPTIONS = {
-    "Varrock": os.path.join(ASSETS_DIR, "Var.png"),
-    "Falador": os.path.join(ASSETS_DIR, "Fal.png"),
-    "Camelot": os.path.join(ASSETS_DIR, "Cam.png"),
-}
 
-choice = None
-config_prompt()
-if choice is None:
-    sys.exit("No teleport selected – exiting.")
-TELEPORT_IMAGE = OPTIONS[choice]
 
 
 
@@ -643,6 +632,19 @@ class PinkNoise:
 
 
 pink = PinkNoise()
+
+# ─────────────────── Teleport selection prompt ─────────────────────
+OPTIONS = {
+    "Varrock": os.path.join(ASSETS_DIR, "Var.png"),
+    "Falador": os.path.join(ASSETS_DIR, "Fal.png"),
+    "Camelot": os.path.join(ASSETS_DIR, "Cam.png"),
+}
+
+choice = None
+config_prompt()
+if choice is None:
+    sys.exit("No teleport selected – exiting.")
+TELEPORT_IMAGE = OPTIONS[choice]
 
 # ───────────────── Anti-ban weights ────────────────────────────────
 # ───────────────── Anti-ban weights ────────────────────────────────


### PR DESCRIPTION
## Summary
- call `config_prompt` after defining frequency constants and helper functions
- update teleport prompt block placement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68638210dbec832f81526bb2dab35f0f