### PR TITLE
Remove obsolete short rest task input

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This project contains **EssayReview.pyw**, a teleport spam bot for Old School Ru
 - Toggle to enable verbose debug logging when troubleshooting.
 - New toggles let you disable stats hovering, Edge/YouTube AFK tasks
   random tab flips and the short Mini-AFK between bursts if desired.
-- Entry to adjust how often short AFK tasks occur during those Mini-AFKs.
 - Three sliders let you tune Mini-AFK, short and long AFK break frequency.
 - Simple login helper that clicks the RuneScape launcher buttons.
 - Hotkeys: **1** to pause/resume, **2** to toggle the console, **3** to quit.
@@ -49,7 +48,7 @@ rename it to `EssayReview.py` and launch it the same way. Logs now always
 print to the terminal so you can monitor activity and debug issues.
 
 
- A configuration window first lets you choose the teleport and toggle options like mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks, tab flipping and the short Mini-AFK after each burst. There is also a field to set how often a short AFK task should run. Three sliders let you tune Mini-AFK, short and long AFK break frequency. You can also enter the confidence threshold used to locate `Cam.png` (or other teleport icons). The default value is **0.8**. After clicking **Start** the bot begins spamming the chosen teleport.
+ A configuration window first lets you choose the teleport and toggle options like mouse overshoot, velocity limit and robust click mode. Additional checkboxes control stats hovering, Edge/YouTube AFK tasks, tab flipping and the short Mini-AFK after each burst. Three sliders let you tune Mini-AFK, short and long AFK break frequency. You can also enter the confidence threshold used to locate `Cam.png` (or other teleport icons). The default value is **0.8**. After clicking **Start** the bot begins spamming the chosen teleport.
 
 On non-Windows systems the window is only shown when the `DISPLAY` environment variable is set. It is also skipped automatically during test runs.
 

--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -295,11 +295,6 @@ def config_prompt():
     tele_conf_var = tk.DoubleVar(value=TELEPORT_CONFIDENCE)
     ttk.Entry(container, textvariable=tele_conf_var, width=5).pack()
 
-    tk.Label(container, text="Short rest task chance:", bg=bg, fg=fg).pack(
-        pady=(10, 0)
-    )
-    short_rest_prob_var = tk.DoubleVar(value=SHORT_REST_TASK_PROB)
-    ttk.Entry(container, textvariable=short_rest_prob_var, width=5).pack()
 
     tk.Label(
         container,
@@ -405,7 +400,6 @@ def config_prompt():
         global ENABLE_AFK, ENABLE_ANTIBAN
         global ENABLE_STATS_HOVER, ENABLE_BROWSER_AFK, ENABLE_TAB_FLIP, choice
         global ENABLE_REST, TELEPORT_CONFIDENCE, DEBUG_LOGGING
-        global SHORT_REST_TASK_PROB
         global AFK_FREQ_LEVEL, MINI_AFK_FREQ_LEVEL, LONG_AFK_FREQ_LEVEL
         global ENABLE_POST_MOVE_DRIFT, POST_MOVE_DRIFT_PROB
         global ENABLE_PRE_CLICK_HOVER, PRE_CLICK_HOVER_PROB
@@ -428,12 +422,6 @@ def config_prompt():
             TELEPORT_CONFIDENCE = max(0.0, min(1.0, float(tele_conf_var.get())))
         except Exception:
             TELEPORT_CONFIDENCE = CONFIDENCE
-        try:
-            SHORT_REST_TASK_PROB = max(
-                0.0, min(1.0, float(short_rest_prob_var.get()))
-            )
-        except Exception:
-            SHORT_REST_TASK_PROB = 1.0
         try:
             MINI_AFK_FREQ_LEVEL = clamp(float(mini_afk_freq_var.get()) / 100, 0.0, 1.0)
         except Exception:


### PR DESCRIPTION
## Summary
- drop Short rest task chance from configuration
- update docs for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68639941c9d8832fbeec5d8bca092f13