### PR TITLE
Update mini AFK rest range

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project contains **EssayReview.pyw**, a teleport spam bot for Old School Ru
   random tab flips and the short Mini-AFK between bursts if desired.
 - Three sliders set the chance of Mini-AFK, short and long AFK breaks
   (0\% never, 100\% always) and default to 50\%.
-- The Mini-AFK rest after each burst now always lasts between 0.5 and 6 seconds.
+- The Mini-AFK rest after each burst now always lasts between 5 and 11 seconds.
 - Simple login helper that clicks the RuneScape launcher buttons.
 - Hotkeys: **1** to pause/resume, **2** to toggle the console, **3** to quit.
 

--- a/src/EssayReview.pyw
+++ b/src/EssayReview.pyw
@@ -376,8 +376,8 @@ def config_prompt():
     def _update_mini_afk_desc(val: str) -> None:
         f = clamp(float(val) / 100, 0.0, 1.0)
         spam_max = int((1 - f) * BASE_SPAM_MAX + f * HIGH_SPAM_MAX)
-        rest_min = clamp((1 - f) * BASE_REST_MIN + f * HIGH_REST_MIN, 0.5, 6.0)
-        rest_max = clamp((1 - f) * BASE_REST_MAX + f * HIGH_REST_MAX, 0.5, 6.0)
+        rest_min = clamp((1 - f) * BASE_REST_MIN + f * HIGH_REST_MIN, 5.0, 11.0)
+        rest_max = clamp((1 - f) * BASE_REST_MAX + f * HIGH_REST_MAX, 5.0, 11.0)
         avg_burst = int((BASE_SPAM_MIN + spam_max) / 2)
         avg_rest = (rest_min + rest_max) / 2
         mini_afk_freq_desc.config(
@@ -601,13 +601,13 @@ def update_afk_settings() -> None:
 
     REST_MIN = clamp(
         (1 - f_rest) * BASE_REST_MIN + f_rest * HIGH_REST_MIN,
-        0.5,
-        6.0,
+        5.0,
+        11.0,
     )
     REST_MAX = clamp(
         (1 - f_rest) * BASE_REST_MAX + f_rest * HIGH_REST_MAX,
-        0.5,
-        6.0,
+        5.0,
+        11.0,
     )
 
     AFK_MIN_SECS = int(
@@ -1512,8 +1512,8 @@ def spam_session():
         burst = gaussian_between(SPAM_MIN, SPAM_MAX)
         rest = clamp(
             gaussian_between(REST_MIN, REST_MAX),
-            0.5,
-            6.0,
+            5.0,
+            11.0,
         )
 
         click_magic_tab()


### PR DESCRIPTION
## Summary
- increase the mini AFK post-burst rest to 5–11 seconds
- document new mini AFK rest range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f75cb8ac832f9d5cfded1a39ab9a